### PR TITLE
Add sdl library for simulator sound and radio joystick control

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -qq && \
         apt-get install --yes \
         software-properties-common \
         build-essential gpg wget \
-        libfox-1.6-dev libclang-6.0-dev
+        libfox-1.6-dev libclang-6.0-dev libsdl1.2-dev
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
         gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \


### PR DESCRIPTION
Version 1.2 is cmake compatible across all OS build platforms.
However OSX users have reported issues with sound not working on later OSX versions.
Version 2.0 has cmake issues. The SDL dev has made a custom cmake module but it is not clear if it works for all OSes. Version 2.0 may fix the sound for OSX users.
To upgrade to V2.0 would need a group of devs covering all the supported OS platforms to sort out the cmake and test. Another one of 'when we have time' jobs.
Note: the need to install SDL 1.2 needs to be added to the various how-to build instructions if devs want simulator sound and optionally radio joystick capabilities.
