### PR TITLE
Install qt tool openssl

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,7 +37,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/edgetx/edgetx-dev:latest
-            ghcr.io/edgetx/edgetx-dev:2.5.1
+            ghcr.io/edgetx/edgetx-dev:2.9.0
 
       - name: Build and Push edgetx-builder
         uses: docker/build-push-action@v2
@@ -47,4 +47,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/edgetx/edgetx-builder:latest
-            ghcr.io/edgetx/edgetx-builder:2.5.1
+            ghcr.io/edgetx/edgetx-builder:2.9.0

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/edgetx/edgetx-dev:2.5.1
+FROM ghcr.io/edgetx/edgetx-dev:2.9.0
 
 RUN useradd --create-home --shell /bin/bash rootless
 RUN mkdir -p /home/rootless/src

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -46,11 +46,20 @@ RUN python3 -m pip install -U pip setuptools \
 ARG QT_VERSION=5.12.9
 # if modules use syntax -m MODULE [MODULE]
 ARG QT_MODULES=
+# supported versions of dependencies
+ARG QT_TOOLS=tools_openssl_x64
 ARG QT_HOST=linux
 ARG QT_TARGET=desktop
 ARG QT_INSTALL_DIR=/opt/qt
 
-RUN aqt install --outputdir ${QT_INSTALL_DIR} ${QT_MODULES} ${QT_VERSION} ${QT_HOST} ${QT_TARGET}
+# cmd 1 installs Qt dev
+# cmd 2 installs tools to individual directories under ${QT_INSTALL_DIR}/Tools
+# cmd 3 Workaround for "libQt5Core.so.5 not found" issue
+#		see https://www.gitmemory.com/issue/Microsoft/WSL/3023/488329451
+
+RUN aqt install-qt --outputdir ${QT_INSTALL_DIR} ${QT_HOST} ${QT_TARGET} ${QT_VERSION} ${QT_ARCH} ${QT_MODULES} && \
+	aqt install-tool --outputdir ${QT_INSTALL_DIR} ${QT_HOST} ${QT_TARGET} ${QT_TOOLS} && \
+	strip --remove-section=.note.ABI-tag ${QT_BASE_DIR}/lib/libQt5Core.so.${QT_VERSION}
 
 ARG QT_BASE_DIR=${QT_INSTALL_DIR}/${QT_VERSION}/gcc_64
 
@@ -61,9 +70,8 @@ ENV QML2_IMPORT_PATH=${QT_BASE_DIR}/qml/
 ENV LD_LIBRARY_PATH=${QT_BASE_DIR}/lib:$LD_LIBRARY_PATH
 ENV PKG_CONFIG_PATH=${QT_BASE_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH
 
-# Workaround for "libQt5Core.so.5 not found" issue
-# see https://www.gitmemory.com/issue/Microsoft/WSL/3023/488329451
-RUN strip --remove-section=.note.ABI-tag ${QT_BASE_DIR}/lib/libQt5Core.so.${QT_VERSION}
+# Companion installer expects this variable to be set
+ENV QT_TOOLS_OPENSSL_ROOT_PATH=${QT_INSTALL_DIR}/Tools/OpenSSL/binary
 
 RUN wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 -O - \
         | tar -xj -C /opt

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -51,6 +51,7 @@ ARG QT_TOOLS=tools_openssl_x64
 ARG QT_HOST=linux
 ARG QT_TARGET=desktop
 ARG QT_INSTALL_DIR=/opt/qt
+ARG QT_BASE_DIR=${QT_INSTALL_DIR}/${QT_VERSION}/gcc_64
 
 # cmd 1 installs Qt dev
 # cmd 2 installs tools to individual directories under ${QT_INSTALL_DIR}/Tools
@@ -60,8 +61,6 @@ ARG QT_INSTALL_DIR=/opt/qt
 RUN aqt install-qt --outputdir ${QT_INSTALL_DIR} ${QT_HOST} ${QT_TARGET} ${QT_VERSION} ${QT_ARCH} ${QT_MODULES} && \
 	aqt install-tool --outputdir ${QT_INSTALL_DIR} ${QT_HOST} ${QT_TARGET} ${QT_TOOLS} && \
 	strip --remove-section=.note.ABI-tag ${QT_BASE_DIR}/lib/libQt5Core.so.${QT_VERSION}
-
-ARG QT_BASE_DIR=${QT_INSTALL_DIR}/${QT_VERSION}/gcc_64
 
 ENV PATH=${QT_BASE_DIR}/bin:$PATH
 ENV QT_PLUGIN_PATH=${QT_BASE_DIR}/plugins/


### PR DESCRIPTION
Qt Network depends on OpenSSL libraries for HTTPS. These may or may not be installed on the client computer and even if installed their version may not be compatible with the Qt version.

This fix installs the Qt tool openssl and sets an environment variable to the install location. This variable is inspected by the Companion installer and passed to cmake find_package(OpenSSL). The installer bundles the .so files into the AppImage.
