### PR TITLE
Sdl2

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
         build-essential \
         dumb-init \
-        libfox-1.6-dev libclang-6.0-dev libsdl1.2-dev \
+        libfox-1.6-dev libclang-6.0-dev libsdl2-dev \
         cmake \
         git \
         zip \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
         build-essential \
         dumb-init \
-        libfox-1.6-dev libclang-6.0-dev libsdl2-dev \
+        libfox-1.6-dev libclang-6.0-dev \
+        libsdl1.2-dev libsdl2-dev \
         cmake \
         git \
         zip \


### PR DESCRIPTION
add SDL2 to the docker image to allow for simu, simulator and companion build with sound and audio support with SDL2