### PR TITLE
fix: gawk missing for `elf-size-report.sh`

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
         unzip \
         file \
         python3-pip \
+        gawk \
         # Install some dependencies required by Qt libs
         libxkbcommon-x11-0 gstreamer1.0-plugins-base && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
It is not that the build system 
> does not detect awk properly on linux, searching for gawk instead....
(and thus does not use radio/util/elf-size-report.sh)

but actually the other way around ... it needs gawk and it is missing 

![image](https://user-images.githubusercontent.com/5500713/235384183-176db5b2-026a-42ba-90a0-6547364f2f59.png)

No changes required for MSYS as gawk must be installed as standard there
![image](https://user-images.githubusercontent.com/5500713/235384518-d629a660-34c6-439c-bd2c-eb8fe53c6e36.png)

