### PR TITLE
fix: `latest` tag not being updated

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,6 +35,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
It seems that while the `latest` tag is automatically managed in some instances (i.e. ref, semver), it only works when the default branch name is `master` , thus

> e.g. if your default branch name is not master, use type=raw with a boolean expression:
```
tags: |
  # set latest tag for master branch
  type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
```

https://github.com/docker/metadata-action#latest-tag