### PR TITLE
fix: ssl hint

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -109,7 +109,7 @@ ENV ASAN_OPTIONS="detect_leaks=0"
 
 # HINTS for cmake find_package
 ENV LIBUSB1_ROOT_DIR=/usr/lib/x86_64-linux-gnu
-ENV LIBSSL1_ROOT_DIR=/usr/lib/x86_64-linux-gnu
+ENV OPENSSL_ROOT_DIR=/usr/lib/x86_64-linux-gnu
 
 VOLUME ["/src"]
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]


### PR DESCRIPTION
The upgrade from SSL version 1 to 3 requires the cmake hint environment variable modified