### PR TITLE
chore(ci): update action and dependency versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             name=ghcr.io/edgetx/edgetx-dev
@@ -38,14 +38,14 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push edgetx-dev
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: dev/
           file: dev/Dockerfile
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -67,7 +67,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             name=ghcr.io/edgetx/edgetx-builder
@@ -79,14 +79,14 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push edgetx-builder
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: builder/
           file: builder/Dockerfile
@@ -99,14 +99,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             name=ghcr.io/edgetx/edgetx-wasi
@@ -118,14 +118,14 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push edgetx-builder
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: wasi/
           file: wasi/Dockerfile

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Python packages installation
-COPY --from=ghcr.io/astral-sh/uv:0.8.2 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.8.24 /uv /uvx /bin/
 ENV VIRTUAL_ENV=/opt/venv
 RUN uv venv \
         --python-preference system --no-python-downloads \

--- a/wasi/Dockerfile
+++ b/wasi/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Python packages installation
-COPY --from=ghcr.io/astral-sh/uv:0.8.2 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.8.24 /uv /uvx /bin/
 ENV VIRTUAL_ENV=/opt/venv
 RUN uv venv \
         --python-preference system --no-python-downloads \


### PR DESCRIPTION
Update all actions to latest stable versions:
- actions/checkout: v3 → v4
- docker/metadata-action: v4 → v5
- docker/login-action: v2 → v3
- docker/build-push-action: v5 → v6

Also update uv container version:
- ghcr.io/astral-sh/uv: 0.8.2 → 0.8.24