### PR TITLE
chore: remove FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-open_collective: edgetx


### PR DESCRIPTION
Removing GitHub FUNDING configuration file - use the org config instead of separate file. 