### PR TITLE
docs: clarify the build / usage steps in the README (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,65 @@
 
 [![Docker Image CI](https://github.com/EdgeTX/build-edgetx/actions/workflows/docker-image.yml/badge.svg)](https://github.com/EdgeTX/build-edgetx/actions/workflows/docker-image.yml)
 
-## How to use
+This repository contains Dockerfiles for container images that provide
+consistent isolated environments for building EdgeTX firmwares.
+It is potentially easier alternative to setting up the build environments
+natively on the host operating system using instructions
+at https://github.com/EdgeTX/edgetx/wiki.
 
-In order to build each image, just `cd` into the directory and execute `make`:
+## edgetx-dev
+
+The `edgetx-dev` image is intended as build environment for local
+firmware builds. It it meant to be used in interactive mode together
+with the EdgeTX sources.
+
+Assuming you have a clone checkout of the https://github.com/EdgeTX/edgetx
+repository or its fork in `~/src/edgetx`, you can build the `edgetx-dev`
+image locally
 ```
-% cd dev && make
-% cd commit-tests && make
-```
-
-### edgetx-dev
-
-The `edgetx-dev` image is meant to be used in interactive mode:
-```
-% cd ~/src/edgetx
-% docker run -it --rm -v $(pwd):/src ghcr.io/edgetx/edgetx-dev bash
-root@02157a542d21:/# cd /src
-```
-
-Then you can just do whatever you need to do with your EdgeTX source tree (compile, test, whatever).
-
-### edgetx-builder
-
-The `edgetx-builder` image is meant to be used in [cloudbuild](https://github.com/EdgeTX/cloudbuild) project. It favours
-rootless user by default, other than that it is exactly the same as `edgetx-dev`.
-
-## Docker repositories
-
-The `edgetx-dev` and `edgetx-builder` image are hosted at Docker hub & Github Container Repository for your convenience.
-
-Pulling from Github Container Repository with this command:
-
-```
-% docker pull ghcr.io/edgetx/edgetx-dev
-% docker pull ghcr.io/edgetx/edgetx-builder
+% make edgetx-dev
 ```
 
-# References
+and then run the container with the EdgeTX sources mounted
+```
+% docker run -it --rm -w /src -v ~/src/edgetx:/src edgetx-dev bash
+```
 
+On an SELinux-enabled system, you may need to add
+`--security-opt label=disable` argument to `docker run` to give the
+container access to your home directory.
+
+On the container shell prompt like
+```
+root@64e263539532:/src#
+```
+you can then just do whatever you need to do with your EdgeTX source
+tree (checkout the desired branch, compile, test).
+If unsure, start with the instructions at
 https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-using-docker-and-Windows-10
+or https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-under-Ubuntu-22.04.
+
+You can skip the step of building the container image and instead use
+the image built from this repository, stored in the GitHub
+Container Registry:
+```
+% docker run -it --rm -w /src -v ~/src/edgetx:/src ghcr.io/edgetx/edgetx-dev bash
+```
+
+## edgetx-builder
+
+The `edgetx-builder` image is meant to be used in
+[cloudbuild](https://github.com/EdgeTX/cloudbuild) project. It favours
+rootless user by default, other than that it is exactly the same
+as `edgetx-dev`.
+
+You can build it locally using
+```
+% make edgetx-builder
+```
+or just use `ghcr.io/edgetx/edgetx-builder`.
+
+## References
+
+- https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-under-Ubuntu-22.04
+- https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-using-docker-and-Windows-10

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 This repository contains Dockerfiles for container images that provide
 consistent isolated environments for building EdgeTX firmwares.
-It is potentially easier alternative to setting up the build environments
+It is a potentially easier alternative to setting up the build environments
 natively on the host operating system using instructions
 at https://github.com/EdgeTX/edgetx/wiki.
 
 ## edgetx-dev
 
 The `edgetx-dev` image is intended as build environment for local
-firmware builds. It it meant to be used in interactive mode together
+firmware builds. It is meant to be used in interactive mode together
 with the EdgeTX sources.
 
 Assuming you have a clone checkout of the https://github.com/EdgeTX/edgetx
@@ -36,6 +36,7 @@ root@64e263539532:/src#
 ```
 you can then just do whatever you need to do with your EdgeTX source
 tree (checkout the desired branch, compile, test).
+
 If unsure, start with the instructions at
 https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-using-docker-and-Windows-10
 or https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-under-Ubuntu-22.04.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,13 @@
 
 [![Docker Image CI](https://github.com/EdgeTX/build-edgetx/actions/workflows/docker-image.yml/badge.svg)](https://github.com/EdgeTX/build-edgetx/actions/workflows/docker-image.yml)
 
-This repository contains Dockerfiles for container images that provide
-consistent isolated environments for building EdgeTX firmwares.
-It is a potentially easier alternative to setting up the build environments
-natively on the host operating system using instructions
-at https://github.com/EdgeTX/edgetx/wiki.
+This repository contains Dockerfiles for container images that provide consistent isolated environments for building EdgeTX firmwares. It is a potentially easier alternative to setting up the build environments natively on the host operating system using instructions at https://github.com/EdgeTX/edgetx/wiki.
 
 ## edgetx-dev
 
-The `edgetx-dev` image is intended as build environment for local
-firmware builds. It is meant to be used in interactive mode together
-with the EdgeTX sources.
+The `edgetx-dev` image is intended as build environment for local firmware builds. It is meant to be used in interactive mode together with the EdgeTX sources.
 
-Assuming you have a clone checkout of the https://github.com/EdgeTX/edgetx
-repository or its fork in `~/src/edgetx`, you can build the `edgetx-dev`
-image locally
+Assuming you have a clone checkout of the https://github.com/EdgeTX/edgetx repository or its fork in `~/src/edgetx`, you can build the `edgetx-dev` image locally
 ```
 % make edgetx-dev
 ```
@@ -26,34 +18,24 @@ and then run the container with the EdgeTX sources mounted
 % docker run -it --rm -w /src -v ~/src/edgetx:/src edgetx-dev bash
 ```
 
-On an SELinux-enabled system, you may need to add
-`--security-opt label=disable` argument to `docker run` to give the
-container access to your home directory.
+On an SELinux-enabled system, you may need to add `--security-opt label=disable` argument to `docker run` to give the container access to your home directory.
 
 On the container shell prompt like
 ```
 root@64e263539532:/src#
 ```
-you can then just do whatever you need to do with your EdgeTX source
-tree (checkout the desired branch, compile, test).
+you can then just do whatever you need to do with your EdgeTX source tree (checkout the desired branch, compile, test).
 
-If unsure, start with the instructions at
-https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-using-docker-and-Windows-10
-or https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-under-Ubuntu-22.04.
+If unsure, start with the instructions at https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-using-docker-and-Windows-10 or https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-under-Ubuntu-22.04.
 
-You can skip the step of building the container image and instead use
-the image built from this repository, stored in the GitHub
-Container Registry:
+You can skip the step of building the container image and instead use the image built from this repository, stored in the GitHub Container Registry:
 ```
 % docker run -it --rm -w /src -v ~/src/edgetx:/src ghcr.io/edgetx/edgetx-dev bash
 ```
 
 ## edgetx-builder
 
-The `edgetx-builder` image is meant to be used in
-[cloudbuild](https://github.com/EdgeTX/cloudbuild) project. It favours
-rootless user by default, other than that it is exactly the same
-as `edgetx-dev`.
+The `edgetx-builder` image is meant to be used in [cloudbuild](https://github.com/EdgeTX/cloudbuild) project. It favours rootless user by default, other than that it is exactly the same as `edgetx-dev`.
 
 You can build it locally using
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ You can build it locally using
 ```
 or just use `ghcr.io/edgetx/edgetx-builder`.
 
+## edgetx-wasi
+
+The `edgetx-wasi` image is meant to be used for building platform agnostic Companion simulator plugins. This functionality is still a work in progress.
+
+You can build it locally using
+```
+% make edgetx-wasi
+```
+or just use `ghcr.io/edgetx/edgetx-wasi`.
+
 ## References
 
 - https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-under-Ubuntu-22.04


### PR DESCRIPTION
An initial attempt to clarify the README a bit.

Related to but not completely fixing https://github.com/EdgeTX/build-edgetx/issues/46.