### PR TITLE
chore: add sk_SK locale for Slovak custom-function sort generation

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && \
     locale-gen zh_CN.UTF-8 cs_CZ.UTF-8 da_DK.UTF-8 de_DE.UTF-8 es_ES.UTF-8 \
                en_US.UTF-8 fi_FI.UTF-8 fr_FR.UTF-8 he_IL.UTF-8 it_IT.UTF-8 \
                ja_JP.UTF-8 ko_KR.UTF-8 nl_NL.UTF-8 pl_PL.UTF-8 pt_PT.UTF-8 \
-               ru_RU.UTF-8 sv_SE.UTF-8 zh_TW.UTF-8 uk_UA.UTF-8 && \
+               ru_RU.UTF-8 sv_SE.UTF-8 sk_SK.UTF-8 zh_TW.UTF-8 uk_UA.UTF-8 && \
     # Install global npm package
     npm i lv_font_conv -g && \
     # Set up Rob Savoury's PPA for newer SDL2


### PR DESCRIPTION
## Summary
- Adds `sk_SK.UTF-8` to the `locale-gen` list in `dev/Dockerfile`, alongside the other radio-language locales.

## Why
`tools/cfn_sorter.sh` in [EdgeTX/edgetx](https://github.com/EdgeTX/edgetx) compiles `cfn_sorter.cpp` against every locale in `RADIO_LANGUAGES` (`radio/src/CMakeLists.txt`) to regenerate `radio/src/cfn_sort.cpp`, including `sk_SK` now that Slovak (SK) support has been added ([EdgeTX/edgetx#6830](https://github.com/EdgeTX/edgetx/pull/6830)). This dev image never generated that locale, so the "Custom function sort order" CI check fails for any Slovak-related PR with:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  locale::facet::_S_create_c_locale name not valid
```
`sk_SK.UTF-8` was already documented (but not generated) in the locale list at the top of `tools/cfn_sorter.sh` — this brings the dev image in sync with that.

## Test plan
- [ ] CI build of the dev image succeeds
- [ ] `locale -a` in the built image includes `sk_SK.UTF-8`
- [ ] `tools/cfn_sorter.sh` (which invokes `LNG_SK`/`sk_SK.UTF-8`) completes without the locale error

🤖 Generated with [Claude Code](https://claude.com/claude-code)