### PR TITLE
dev: add just and m4

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -13,6 +13,7 @@ ARG QT_ARCH=linux_gcc_64
 ARG QT_INSTALL_DIR=/opt/qt
 ARG GCC_ARM_VERSION=14.2.rel1
 ARG NODE_VERSION=20.x
+ARG JUST_VERSION=1.57.0
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -47,6 +48,8 @@ RUN apt-get update && \
         file \
         python3-dev \
         gawk \
+        # For generating sim_string_list.h from string_list.h
+        m4 \
         # Install dfu-util and libusb
         dfu-util \
         # For font generation and cfn sorting
@@ -106,6 +109,10 @@ RUN wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/${GCC_ARM
 
 ENV PATH=/opt/arm-gnu-toolchain-${GCC_ARM_VERSION}-x86_64-arm-none-eabi/bin/:${PATH}
 ENV ASAN_OPTIONS="detect_leaks=0"
+
+# Install just - runs the Justfile codegen recipes (see edgetx/Justfile)
+RUN wget --quiet -O - https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz \
+    | tar -xz -C /usr/local/bin just
 
 # HINTS for cmake find_package
 ENV OPENSSL_ROOT_DIR=/usr/lib/x86_64-linux-gnu


### PR DESCRIPTION
## Summary
- Adds `m4` to the `edgetx-dev` image's apt packages — needed to regenerate `radio/src/translations/sim_string_list.h` from `string_list.h`, and not part of Ubuntu's base or `build-essential`.
- Installs `just` (pinned via `JUST_VERSION`, same version currently pinned in edgetx's CI) — edgetx's `Justfile` drives its codegen recipes (fonts, cfn sort, YAML parsers, radio list, and a new sim string list generator), and today its CI reinstalls `just` from scratch on every run.

Once this lands in `:latest`, edgetx's `codegen_drift.yml`/`action.yml` can drop the per-run `just` install and version pin, and its devcontainer won't need a `postCreateCommand` addition either.

## Test plan
- [ ] CI build of the `dev` image succeeds
- [ ] `docker run --rm ghcr.io/edgetx/edgetx-dev:<branch-tag> bash -c 'just --version && m4 --version'`